### PR TITLE
provide option to not animate thumb on push

### DIFF
--- a/PWSwitch.podspec
+++ b/PWSwitch.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PWSwitch'
-  s.version          = '1.1.2'
+  s.version          = '1.2.0'
   s.summary          = 'Highly customizable UISwitch built with CALayers and CAAnimations'
 
 # This description is used to generate tags and improve search results.

--- a/PWSwitch/PWSwitch.swift
+++ b/PWSwitch/PWSwitch.swift
@@ -136,6 +136,19 @@ open class PWSwitch: UIControl {
         }
     }
     fileprivate var _thumbCornerRadius: CGFloat = 7
+
+    @IBInspectable open dynamic var expandThumbOnPush: Bool { // UI_APPEARANCE_SELECTOR
+        get { return self._expandThumbOnPush }
+        set {
+            self._expandThumbOnPush = newValue
+            if newValue {
+                thumbDelta = 6
+            } else {
+                thumbDelta = 0
+            }
+        }
+    }
+    fileprivate var _expandThumbOnPush: Bool = true
     
     @IBInspectable open dynamic var shouldFillOnPush: Bool { // UI_APPEARANCE_SELECTOR
         get { return self._shouldFillOnPush }
@@ -175,8 +188,8 @@ open class PWSwitch: UIControl {
     }
     fileprivate var _shadowStrength: CGFloat = 1
     
-    let thumbDelta:CGFloat = 6
-    
+    private var thumbDelta:CGFloat = 6
+
     let scale = UIScreen.main.scale
     
     override public init(frame: CGRect) {
@@ -283,7 +296,7 @@ open class PWSwitch: UIControl {
             thumbBoundsAnimation.fillMode = CAMediaTimingFillMode.forwards
             thumbBoundsAnimation.duration = 0.25
             thumbBoundsAnimation.isRemovedOnCompletion = false
-            
+
             let thumbPosAnimation = CABasicAnimation(keyPath: "position")
             thumbPosAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.175, 0.885, 0.32, 1.275)
             thumbPosAnimation.fromValue = NSValue(cgPoint: getThumbOnPos())
@@ -313,7 +326,7 @@ open class PWSwitch: UIControl {
             animThumbGroup.fillMode = CAMediaTimingFillMode.forwards
             animThumbGroup.isRemovedOnCompletion = false
             animThumbGroup.animations = [thumbBoundsAnimation, thumbPosAnimation, thumbBorderColorAnimation, thumbFillColorAnimation]
-            
+
             thumbLayer.removeAllAnimations()
             thumbLayer.add(animThumbGroup, forKey: "thumbAnimation")
             
@@ -325,7 +338,7 @@ open class PWSwitch: UIControl {
             bgBorderAnimation.fillMode = CAMediaTimingFillMode.forwards
             bgBorderAnimation.duration = 0.25
             bgBorderAnimation.isRemovedOnCompletion = false
-            
+
             let bgBorderColorAnimation = CABasicAnimation(keyPath: "borderColor")
             bgBorderColorAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.55, 0.055, 0.675, 0.19)
             bgBorderColorAnimation.fromValue = trackOffBorderColor.cgColor
@@ -587,7 +600,7 @@ open class PWSwitch: UIControl {
     
     fileprivate func offToOnAnim() {
         
-        
+
         let bgBorderColorAnimation = CABasicAnimation(keyPath: "borderColor")
         bgBorderColorAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.165, 0.84, 0.44, 1)
         bgBorderColorAnimation.fromValue = trackOffPushBorderColor.cgColor

--- a/PWSwitch/PWSwitch.swift
+++ b/PWSwitch/PWSwitch.swift
@@ -296,7 +296,7 @@ open class PWSwitch: UIControl {
             thumbBoundsAnimation.fillMode = CAMediaTimingFillMode.forwards
             thumbBoundsAnimation.duration = 0.25
             thumbBoundsAnimation.isRemovedOnCompletion = false
-
+            
             let thumbPosAnimation = CABasicAnimation(keyPath: "position")
             thumbPosAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.175, 0.885, 0.32, 1.275)
             thumbPosAnimation.fromValue = NSValue(cgPoint: getThumbOnPos())
@@ -326,7 +326,7 @@ open class PWSwitch: UIControl {
             animThumbGroup.fillMode = CAMediaTimingFillMode.forwards
             animThumbGroup.isRemovedOnCompletion = false
             animThumbGroup.animations = [thumbBoundsAnimation, thumbPosAnimation, thumbBorderColorAnimation, thumbFillColorAnimation]
-
+            
             thumbLayer.removeAllAnimations()
             thumbLayer.add(animThumbGroup, forKey: "thumbAnimation")
             
@@ -338,7 +338,7 @@ open class PWSwitch: UIControl {
             bgBorderAnimation.fillMode = CAMediaTimingFillMode.forwards
             bgBorderAnimation.duration = 0.25
             bgBorderAnimation.isRemovedOnCompletion = false
-
+            
             let bgBorderColorAnimation = CABasicAnimation(keyPath: "borderColor")
             bgBorderColorAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.55, 0.055, 0.675, 0.19)
             bgBorderColorAnimation.fromValue = trackOffBorderColor.cgColor
@@ -600,7 +600,7 @@ open class PWSwitch: UIControl {
     
     fileprivate func offToOnAnim() {
         
-
+        
         let bgBorderColorAnimation = CABasicAnimation(keyPath: "borderColor")
         bgBorderColorAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.165, 0.84, 0.44, 1)
         bgBorderColorAnimation.fromValue = trackOffPushBorderColor.cgColor

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ if pwSwitch.on {
 - `trackInset` - track inset from the outer control frame. Usable if thumb is bigger than track
 - `thumbShadowColor` - thumb shadow color. Alpha value can be used to change shadow opacity
 - `shadowStrength` - overall strength of thumb shadow
+- `expandThumbOnPush` - whether the thumb grows when pressed
 
 ## Issues
 


### PR DESCRIPTION
The thumb grows and shrinks in size by `thumbDelta` amount whenever touches begin and end. This behaviour may not always be desirable, e.g. in cases where an image is placed in the thumb and becomes distorted as a result of the animation. 

This PR introduces the `expandThumbOnPush` variable. When `true` (the default), current behaviour is maintained. When `false`, the thumb does not change in size when pressed. 